### PR TITLE
backpropagate() changed to backup()

### DIFF
--- a/monte_carlo_tree_search.py
+++ b/monte_carlo_tree_search.py
@@ -1,4 +1,4 @@
-import torch
+
 import math
 import numpy as np
 
@@ -137,7 +137,7 @@ class MCTS:
 
         return root
 
-    def backpropagate(self, search_path, value, to_play):
+    def backup(self, search_path, value, to_play):
         """
         At the end of a simulation, we propagate the evaluation all the way up the tree
         to the root.


### PR DESCRIPTION
Changed the backpropagate() function in monte_carlo_tree_search.py to backup() and removed the torch import as it was unused import in this python file